### PR TITLE
allow different frame sizes (not just 8 or 0)

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -28,6 +28,8 @@ def main():
     # Prepare frames
     data = b"\x12\x34\x56\x78\x9A\xBC\xDE\xF0"
     sff_frame = GsUsbFrame(can_id=0x7FF, data=data)
+    sff_frame2 = GsUsbFrame(can_id=0x270, data=[0x00, 0x02, 0x4f, 0x55])
+    sff_frame3 = GsUsbFrame(can_id=0x350, data=[0xff, 0xee, 0xdd, 0xcc, 0xbb, 0xaa])
     sff_none_data_frame = GsUsbFrame(can_id=0x7FF)
     err_frame = GsUsbFrame(can_id=0x7FF | CAN_ERR_FLAG, data=data)
     eff_frame = GsUsbFrame(can_id=0x12345678 | CAN_EFF_FLAG, data=data)
@@ -37,6 +39,8 @@ def main():
     rtr_with_data_frame = GsUsbFrame(can_id=0x7FF | CAN_RTR_FLAG, data=data)
     frames = [
         sff_frame,
+        sff_frame2,
+        sff_frame3,
         sff_none_data_frame,
         err_frame,
         eff_frame,

--- a/gs_usb/gs_usb_frame.py
+++ b/gs_usb/gs_usb_frame.py
@@ -7,16 +7,21 @@ GS_USB_FRAME_SIZE = 24
 
 
 class GsUsbFrame:
-    def __init__(self, can_id=0, data=[0x00] * 8):
+    def __init__(self, can_id=0, data=[]):
         self.echo_id = GS_USB_ECHO_ID
         self.can_id = can_id
         self.channel = 0
         self.flags = 0
         self.reserved = 0
-        self.data = data
         self.timestamp_us = 0
 
-        self.can_dlc = len(self.data)
+        if type(data) == bytes:
+            z = list(data)
+        else:
+            z = data
+
+        self.data = z + [0] * (8 - len(z))
+        self.can_dlc = len(data)
 
     @property
     def arbitration_id(self) -> int:
@@ -45,6 +50,6 @@ class GsUsbFrame:
         data = (
             "remote request"
             if self.is_remote_frame
-            else " ".join("{:02X}".format(b) for b in self.data)
+            else " ".join("{:02X}".format(b) for b in self.data[:self.can_dlc])
         )
-        return "{: >8X}   [{}]  {}".format(self.arbitration_id, self.can_dlc, data)    
+        return "{: >8X}   [{}]  {}".format(self.arbitration_id, self.can_dlc, data)


### PR DESCRIPTION
This pull request is to allow frames with different sizes. Apparently gs_usb driver has fixed 8 bytes frames, so when dlc=0 it just sends 8 byte data filled with zeroes.

However current python module does not allow for different sizes apart from 0 or 8, so this pull request tries to fix that. It still sends 8 bytes, but all unused bytes are set to 0.

Also the string formatting has been improved to only show relevant bytes (those specified by dlc).

![demo_frames](https://user-images.githubusercontent.com/1391368/97178057-429cb980-1797-11eb-97c3-41c3d1c3fd9a.png)