### PR TITLE
fixed timestamp_us overflow

### DIFF
--- a/gs_usb/gs_usb_frame.py
+++ b/gs_usb/gs_usb_frame.py
@@ -61,7 +61,7 @@ class GsUsbFrame:
         if (hw_timestamp == True):
             return pack("<2I12BI",
                 self.echo_id, self.can_id, self.can_dlc, self.channel,
-                self.flags, self.reserved, *self.data, self.timestamp_us
+                self.flags, self.reserved, *self.data, self.timestamp_us & 0xffffffff
             )
         else:
             return pack("<2I12B",


### PR DESCRIPTION
When packing timestamp_us into a 32-bit unsigned integer, struct.pack can throws an exception if the number is bigger than 2^32.

Some software sets the frame timestamp to be time.time(), meaning that the exception is thrown immediately. (see scapy: https://github.com/secdev/scapy/blob/master/scapy/contrib/cansocket_python_can.py#L319)

I would recommend doing a bitwise and with 0xffffffff to ensure the timestamp fits into the 32-bit integer